### PR TITLE
Use convert_options if available.

### DIFF
--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -41,6 +41,13 @@ module Paperclip
     def make
       ::Av.logger = Paperclip.logger
       @cli.add_source @file
+
+      if @convert_options && @convert_options.size > 0
+        @convert_options.each { |k,v|
+          @cli.add_output_param({k=>v})
+        } if @convert_options.is_a?(Hash)
+      end
+      
       dst = Tempfile.new([@basename, @format ? ".#{@format}" : ''])
       dst.binmode
       


### PR DESCRIPTION
Currently, passing in :convert_options => {...} as part of a style
does not get used by the paperclip processor.  This prevents
additional switches from being passed to ffmpeg/av.

This change adds the passed options to the cli object.