### PR TITLE
Readds auto-rotate option

### DIFF
--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -56,6 +56,18 @@ module Paperclip
         if output_is_image?
           @time = @time.call(@meta, @options) if @time.respond_to?(:call)
           @cli.filter_seek @time
+
+          if @auto_rotate && !@meta[:rotate].nil?
+            log "Adding rotation #{@meta[:rotate]}"
+            case @meta[:rotate]
+            when 90
+              @convert_options[:output][:vf] = "'transpose=1'"
+            when 180
+              @convert_options[:output][:vf] = "'vflip, hflip'"
+            when 270
+              @convert_options[:output][:vf] = "'transpose=2'"
+            end
+          end
         end
 
         if @convert_options.present?

--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -56,18 +56,7 @@ module Paperclip
         if output_is_image?
           @time = @time.call(@meta, @options) if @time.respond_to?(:call)
           @cli.filter_seek @time
-
-          if @auto_rotate && !@meta[:rotate].nil?
-            log "Adding rotation #{@meta[:rotate]}"
-            case @meta[:rotate]
-            when 90
-              @convert_options[:output][:vf] = "'transpose=1'"
-            when 180
-              @convert_options[:output][:vf] = "'vflip, hflip'"
-            when 270
-              @convert_options[:output][:vf] = "'transpose=2'"
-            end
-          end
+          @cli.filter_rotate @meta[:rotate] if @auto_rotate && !@meta[:rotate].nil?
         end
 
         if @convert_options.present?


### PR DESCRIPTION
Thumbnails are being generated with the wrong orientation even when using the auto_rotate option.

Digging through the source, I found out that auto_rotation option is not doing anything.
I also found out that the paperclip-ffmpeg gem did support this before: https://github.com/owahab/paperclip-ffmpeg/commit/3e3670432378bd0648b4ffd51d3038f2a3f620f2

So I basically applied the same to the paperclip-av-transcoder gem.
I'm not sure why this was removed but it seems to be working fine...