### PR TITLE
Remove tempfile if exception is thrown

### DIFF
--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -74,9 +74,12 @@ module Paperclip
 
         begin
           @cli.run
-          log "Successfully transcoded #{@basename} to #{dst}"
+          log "Successfully transcoded #{@basename} to #{dst.path}"
         rescue Cocaine::ExitStatusError => e
-          raise Paperclip::Error, "error while transcoding #{@basename}: #{e}" if @whiny
+          if @whiny
+            dst.close!
+            raise Paperclip::Error, "error while transcoding #{@basename}: #{e}"
+          end
         end
       else
         log "Unsupported file #{@file.path}"


### PR DESCRIPTION
Proactively clean up the tempfile if Av throws an exception and whiny is true.
This prevents tempfiles from lingering around unnecessarily until the next GC.

See related issue: https://github.com/thoughtbot/paperclip/issues/1326