### PR TITLE
Move AV's `add_destination` after `convert_options` to permit second input (e.g. watermark).

### DIFF
--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -50,7 +50,6 @@ module Paperclip
       if @meta
         log "Transcoding supported file #{@file.path}"
         @cli.add_source(@file.path)
-        @cli.add_destination(dst.path)
         @cli.reset_input_filters
 
         if output_is_image?
@@ -71,6 +70,8 @@ module Paperclip
             end
           end
         end
+        
+        @cli.add_destination(dst.path)
 
         begin
           @cli.run

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "paperclip", ">=2.5.2"
+  spec.add_dependency "kt-paperclip", ">= 6.4.1"
   spec.add_dependency "av", "~> 0.9.0"
 end


### PR DESCRIPTION
When you call `@cli.add_destination(dst.path)`, AV will add various output formats automatically, based on the destination filename. You can see that here: 

https://github.com/ruby-av/av/blob/f00e6295e8f175262c99f2a5c3f1d4ed75c2c436/lib/av/commands/base.rb#L134
```ruby
def output_format format
  @output_format = format
  case format.to_s
  when /jpg$/, /jpeg$/, /png$/, /gif$/ # Images
    add_output_param 'f', 'image2'
    add_output_param 'vframes', '1'
  when /webm$/ # WebM
    add_output_param 'f', 'webm'
    add_output_param 'acodec', 'libvorbis'
    add_output_param 'vcodec', 'libvpx'
  when /ogv$/ # Ogg Theora
    add_output_param 'f', 'ogg'
    add_output_param 'acodec', 'libvorbis'
    add_output_param 'vcodec', 'libtheora'
  when /mp4$/
    add_output_param 'acodec', 'aac'
    add_output_param 'strict', 'experimental'
  end
end
```

These output params will naturally come before the `output_options` specified in this gem, which is probably fine most of the time but it prevents some advanced but common uses, like adding a watermark overlay to your videos. 

For example, creating a watermark overlay on a video would look like this: 

```ruby
mp4: { 
  format: 'mp4', 
  convert_options: { 
    output: { 
      'i': 'my-watermark.png',
      'filter_complex': 'overlay=10:10',
    } 
  } 
}
```

However, this generates an FFMPEG command that looks like this: 

```bash
ffmpeg -i my-input-video.mkv -acodec aac -strict experimental -i my-watermark.png -filter_complex overlay=10:10 -y my-output-video.mp4
```

That causes a problem because it tries to apply the `-acodec aac` to the `-i my-watermark.png`, which is an image and you get an error message like this: 

```bash
decoding for stream 0 failed
Could not find codec parameters for stream 0 (Audio: aac, 0 channels, fltp): unspecified sample rate
Consider increasing the value for the 'analyzeduration' and 'probesize' options
```

By moving the `add_destination` after we add our `convert_options` to the `@cli`, it generates a FFMPEG command like this: 

```bash
ffmpeg -i my-input-video.mkv -i my-watermark.png -filter_complex overlay=10:10 -acodec aac -strict experimental -y my-output-video.mp4
```

This properly applies the "default" output options from the AV gem to the output file, and everybody is happy.