### PR TITLE
Fix issue with shorter vides (less than 3 seconds) causing issues with thumbnail generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In your model:
 This will produce:
 
 1. A transcoded `:medium` FLV file with the requested dimensions if they will match the aspect ratio of the original file, otherwise, width will be maintained and height will be recalculated to keep the original aspect ration.
-2. A screenshot `:thumb` with the requested dimensions regardless of the aspect ratio.
+2. A screenshot `:thumb` with the requested dimensions regardless of the aspect ratio and with `:time => 10`, it captures a frame from the 10th second of the video.
 
 ### Meta Data
 

--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -30,7 +30,7 @@ module Paperclip
         @shrink_only      = @keep_aspect    && modifier == '>'
       end
 
-      @time             = options[:time].nil? ? 0 : options[:time]
+      @time             = options[:time].nil? ? default_time : options[:time]
       @auto_rotate      = options[:auto_rotate].nil? ? false : options[:auto_rotate]
       @pad_color        = options[:pad_color].nil? ? "black" : options[:pad_color]
 
@@ -104,6 +104,11 @@ module Paperclip
 
     def output_is_image?
       !!@format.to_s.match(/jpe?g|png|gif$/)
+    end
+
+    def default_time
+      duration = @meta[:duration].to_f rescue 0
+      duration < 3 ? 0 : 3
     end
   end
 

--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -30,7 +30,7 @@ module Paperclip
         @shrink_only      = @keep_aspect    && modifier == '>'
       end
 
-      @time             = options[:time].nil? ? 3 : options[:time]
+      @time             = options[:time].nil? ? 0 : options[:time]
       @auto_rotate      = options[:auto_rotate].nil? ? false : options[:auto_rotate]
       @pad_color        = options[:pad_color].nil? ? "black" : options[:pad_color]
 


### PR DESCRIPTION
I've recently encountered some challenges while working with this gem, particularly in understanding the `:time` parameter, which was not clearly documented. 

Moreover, I faced issues when uploading videos shorter than 3 seconds. After a thorough review and analysis of the source code, I have implemented a fix. 
As a solution, I've set the default value to check the video's length and, if it falls outside the `:time` value, automatically selecting an appropriate frame, preferably the first one.

I've also included a small description of the `:time` parameter to enhance the documentation.